### PR TITLE
fix: corrige erros de compilação nos handlers MediatR

### DIFF
--- a/src/VendaZap.Application/Features/Messages/ProcessInboundMessage.cs
+++ b/src/VendaZap.Application/Features/Messages/ProcessInboundMessage.cs
@@ -17,7 +17,7 @@ public record ProcessInboundMessageCommand(
     string MessageBody,
     string WhatsAppMessageId,
     MessageType MessageType = MessageType.Text,
-    string? MediaUrl = null) : IRequest<r>;
+    string? MediaUrl = null) : IRequest<Result>;
 
 public class ProcessInboundMessageCommandHandler : IRequestHandler<ProcessInboundMessageCommand, Result>
 {
@@ -47,7 +47,7 @@ public class ProcessInboundMessageCommandHandler : IRequestHandler<ProcessInboun
         _uow = uow; _logger = logger;
     }
 
-    public async Task<r> Handle(ProcessInboundMessageCommand request, CancellationToken ct)
+    public async Task<Result> Handle(ProcessInboundMessageCommand request, CancellationToken ct)
     {
         // Idempotency: skip if already processed
         var existing = await _messages.GetByWhatsAppIdAsync(request.WhatsAppMessageId, ct);
@@ -196,7 +196,7 @@ public class ProcessInboundMessageCommandHandler : IRequestHandler<ProcessInboun
 public record ProcessMessageStatusCommand(
     string WhatsAppMessageId,
     string Status,
-    DateTime Timestamp) : IRequest<r>;
+    DateTime Timestamp) : IRequest<Result>;
 
 public class ProcessMessageStatusCommandHandler : IRequestHandler<ProcessMessageStatusCommand, Result>
 {
@@ -208,7 +208,7 @@ public class ProcessMessageStatusCommandHandler : IRequestHandler<ProcessMessage
         _messages = messages; _uow = uow;
     }
 
-    public async Task<r> Handle(ProcessMessageStatusCommand request, CancellationToken ct)
+    public async Task<Result> Handle(ProcessMessageStatusCommand request, CancellationToken ct)
     {
         var message = await _messages.GetByWhatsAppIdAsync(request.WhatsAppMessageId, ct);
         if (message is null) return Result.Success();
@@ -222,10 +222,5 @@ public class ProcessMessageStatusCommandHandler : IRequestHandler<ProcessMessage
 
         await _uow.SaveChangesAsync(ct);
         return Result.Success();
-    }
-
-    Task<Result> IRequestHandler<ProcessMessageStatusCommand, Result>.Handle(ProcessMessageStatusCommand request, CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/src/VendaZap.Application/Features/Orders/OrdersFeature.cs
+++ b/src/VendaZap.Application/Features/Orders/OrdersFeature.cs
@@ -152,7 +152,7 @@ public class CreateOrderFromConversationCommandHandler : IRequestHandler<CreateO
 }
 
 public record UpdateOrderStatusCommand(Guid OrderId, OrderStatus NewStatus, string? TrackingCode = null, string? CancellationReason = null)
-    : IRequest<r>;
+    : IRequest<Result>;
 
 public class UpdateOrderStatusCommandHandler : IRequestHandler<UpdateOrderStatusCommand, Result>
 {
@@ -165,7 +165,7 @@ public class UpdateOrderStatusCommandHandler : IRequestHandler<UpdateOrderStatus
         _orders = orders; _uow = uow; _tenant = tenant;
     }
 
-    public async Task<r> Handle(UpdateOrderStatusCommand request, CancellationToken ct)
+    public async Task<Result> Handle(UpdateOrderStatusCommand request, CancellationToken ct)
     {
         var order = await _orders.GetByIdAsync(request.OrderId, ct);
         if (order is null || order.TenantId != _tenant.TenantId)


### PR DESCRIPTION
Substitui typos `IRequest<r>` e `Task<r>` por `IRequest<Result>` e `Task<Result>` em ProcessInboundMessageCommand, ProcessMessageStatusCommand e UpdateOrderStatusCommand. Remove método Handle duplicado com NotImplementedException no ProcessMessageStatusCommandHandler.

https://claude.ai/code/session_015fHZcVbSZeXWE11rZ2tJ81

@claude