### PR TITLE
feat(#12): implementar motor de IA com GPT-4o para respostas de venda

### DIFF
--- a/src/VendaZap.Application/Features/Messages/ProcessInboundMessage.cs
+++ b/src/VendaZap.Application/Features/Messages/ProcessInboundMessage.cs
@@ -27,17 +27,20 @@ public class ProcessInboundMessageCommandHandler : IRequestHandler<ProcessInboun
     private readonly IProductRepository _products;
     private readonly ITenantRepository _tenants;
     private readonly IAutoReplyTemplateRepository _autoReplies;
-    private readonly IAiConversationService _ai;
+    private readonly IConversationAIService _ai;
     private readonly IWhatsAppService _whatsApp;
     private readonly INotificationService _notifications;
     private readonly IUnitOfWork _uow;
     private readonly ILogger<ProcessInboundMessageCommandHandler> _logger;
 
+    private const int ConfidenceThreshold = 70;
+    private const int HistoryLimit = 20;
+
     public ProcessInboundMessageCommandHandler(
         IContactRepository contacts, IConversationRepository conversations,
         IMessageRepository messages, IProductRepository products,
         ITenantRepository tenants, IAutoReplyTemplateRepository autoReplies,
-        IAiConversationService ai, IWhatsAppService whatsApp,
+        IConversationAIService ai, IWhatsAppService whatsApp,
         INotificationService notifications, IUnitOfWork uow,
         ILogger<ProcessInboundMessageCommandHandler> logger)
     {
@@ -116,55 +119,118 @@ public class ProcessInboundMessageCommandHandler : IRequestHandler<ProcessInboun
                 return;
             }
 
-            // Check for human transfer keywords
-            if (IsHumanTransferRequest(userMessage) && tenant.IsHumanTakeoverEnabled)
+            // Send welcome message for brand-new conversations without AI call
+            if (isNewConversation)
             {
-                conversation.TransferToHuman();
-                _conversations.Update(conversation);
-                await SendBotMessageAsync(tenant, conversation, contact,
-                    "Ok! Vou chamar um atendente para você. Por favor, aguarde um momento. 🙏", ct);
-                await _notifications.NotifyHumanTakeoverRequestAsync(tenant.Id, conversation.Id, contact.GetDisplayName(), ct);
+                var welcome = tenant.WelcomeMessage ?? "Olá! 👋 Como posso te ajudar?";
+                await SendBotMessageAsync(tenant, conversation, contact, welcome, ct);
                 return;
             }
 
-            // Build AI context with products
+            // Check for explicit human transfer keywords before hitting AI
+            if (IsHumanTransferRequest(userMessage) && tenant.IsHumanTakeoverEnabled)
+            {
+                await TransferToHumanAsync(tenant, conversation, contact, ct);
+                return;
+            }
+
+            // Load last 20 messages as AI context
+            var recentMessages = await _messages.GetByConversationAsync(conversation.Id, 1, HistoryLimit, ct);
+            var history = recentMessages
+                .OrderBy(m => m.CreatedAt)
+                .Select(m => new ConversationMessageContext(
+                    Role: m.Direction == MessageDirection.Inbound ? "user" : "assistant",
+                    Content: m.Content,
+                    SentAt: m.CreatedAt))
+                .ToList();
+
+            // Build AI context with tenant and product data
             var products = await _products.GetByTenantAsync(tenant.Id, true, ct);
-            var productSummaries = products.Select(p => new ProductSummary(
-                p.Id, p.Name, p.Price.Amount, p.Description, p.IsAvailable())).ToList();
+            var productInfos = products.Select(p =>
+                new AiProductInfo(p.Id, p.Name, p.Price.Amount, p.Description, p.IsAvailable())).ToList();
 
-            var context = new SalesContext(
-                tenant.Name,
-                contact.GetDisplayName(),
-                conversation.Stage.ToString(),
-                productSummaries,
-                conversation.CartJson,
-                BuildPaymentInfoString(tenant));
-
-            // Get/create AI thread
+            // Get/create AI thread for conversation tracking
             if (conversation.AiThreadId is null)
             {
-                var threadId = await _ai.CreateThreadAsync(ct);
+                var threadId = Guid.NewGuid().ToString("N");
                 conversation.SetAiThreadId(threadId);
                 _conversations.Update(conversation);
                 await _uow.SaveChangesAsync(ct);
             }
 
-            var aiResponse = isNewConversation
-                ? tenant.WelcomeMessage ?? "Olá! 👋 Como posso te ajudar?"
-                : await _ai.GetSalesResponseAsync(tenant.Id, userMessage, context, ct);
+            var aiContext = new AiSalesContext(
+                TenantName: tenant.Name,
+                ContactName: contact.GetDisplayName(),
+                CurrentStage: conversation.Stage.ToString(),
+                AvailableProducts: productInfos,
+                CartSummary: conversation.CartJson,
+                PaymentInfo: BuildPaymentInfoString(tenant),
+                CustomInstructions: null);
 
-            await SendBotMessageAsync(tenant, conversation, contact, aiResponse, ct);
+            // Call the AI engine
+            var aiResponse = await _ai.ProcessMessageAsync(tenant.Id, userMessage, history, aiContext, ct);
+
+            _logger.LogInformation(
+                "AI response for conversation {ConversationId}: intent={Intent}, confidence={Confidence}, next={NextAction}",
+                conversation.Id, aiResponse.Intent, aiResponse.Confidence, aiResponse.NextAction);
+
+            // Fallback: low confidence → transfer to human
+            if (aiResponse.Confidence < ConfidenceThreshold && tenant.IsHumanTakeoverEnabled)
+            {
+                _logger.LogInformation(
+                    "Low AI confidence ({Confidence}) for conversation {ConversationId}. Transferring to human.",
+                    aiResponse.Confidence, conversation.Id);
+                await TransferToHumanAsync(tenant, conversation, contact, ct);
+                return;
+            }
+
+            // Intent-based routing
+            if (aiResponse.Intent is "transferir_humano" && tenant.IsHumanTakeoverEnabled)
+            {
+                await TransferToHumanAsync(tenant, conversation, contact, ct);
+                return;
+            }
+
+            // Advance conversation stage based on intent
+            AdvanceStageFromIntent(conversation, aiResponse.Intent);
+
+            await SendBotMessageAsync(tenant, conversation, contact, aiResponse.Message, ct);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error generating bot response for conversation {ConversationId}", conversation.Id);
-            // Fallback message
             await SendBotMessageAsync(tenant, conversation, contact,
                 "Desculpe, ocorreu um erro. Tente novamente em instantes.", ct);
         }
     }
 
-    private async Task SendBotMessageAsync(Tenant tenant, Conversation conversation, Contact contact, string content, CancellationToken ct)
+    private async Task TransferToHumanAsync(
+        Tenant tenant, Conversation conversation, Contact contact, CancellationToken ct)
+    {
+        conversation.TransferToHuman();
+        _conversations.Update(conversation);
+        await SendBotMessageAsync(tenant, conversation, contact,
+            "Ok! Vou chamar um atendente para você. Por favor, aguarde um momento. 🙏", ct);
+        await _notifications.NotifyHumanTakeoverRequestAsync(
+            tenant.Id, conversation.Id, contact.GetDisplayName(), ct);
+    }
+
+    private static void AdvanceStageFromIntent(Conversation conversation, string intent)
+    {
+        var next = intent switch
+        {
+            "consulta_produto"  => ConversationStage.BrowsingProducts,
+            "interesse_compra"  => ConversationStage.ProductSelected,
+            "finalizar_pedido"  => ConversationStage.ConfirmingOrder,
+            _                   => (ConversationStage?)null
+        };
+
+        if (next.HasValue && next.Value > conversation.Stage)
+            conversation.AdvanceStage(next.Value);
+    }
+
+    private async Task SendBotMessageAsync(
+        Tenant tenant, Conversation conversation, Contact contact, string content, CancellationToken ct)
     {
         var outbound = Message.CreateOutbound(conversation.Id, tenant.Id, content, MessageSource.Bot);
         await _messages.AddAsync(outbound, ct);

--- a/src/VendaZap.Domain/Interfaces/IConversationAIService.cs
+++ b/src/VendaZap.Domain/Interfaces/IConversationAIService.cs
@@ -1,0 +1,53 @@
+namespace VendaZap.Domain.Interfaces;
+
+/// <summary>
+/// Structured AI response with detected intent and confidence score.
+/// </summary>
+public record AiConversationResponse(
+    string Message,
+    string Intent,
+    IEnumerable<string> ProductsMentioned,
+    string NextAction,
+    int Confidence);
+
+/// <summary>
+/// A single message from the conversation history passed to the AI as context.
+/// </summary>
+public record ConversationMessageContext(string Role, string Content, DateTime SentAt);
+
+/// <summary>
+/// Sales context supplied to the AI engine so it can generate personalized responses.
+/// </summary>
+public record AiSalesContext(
+    string TenantName,
+    string ContactName,
+    string? CurrentStage,
+    IEnumerable<AiProductInfo> AvailableProducts,
+    string? CartSummary,
+    string? PaymentInfo,
+    string? CustomInstructions = null);
+
+/// <summary>
+/// Lightweight product info sent to the AI.
+/// </summary>
+public record AiProductInfo(Guid Id, string Name, decimal Price, string Description, bool InStock);
+
+/// <summary>
+/// Domain contract for AI-powered conversation processing.
+/// Implementations must detect intent, return structured responses and a confidence score.
+/// </summary>
+public interface IConversationAIService
+{
+    /// <summary>
+    /// Process an inbound message and return a structured AI response.
+    /// Detects one of the following intents:
+    ///   consulta_produto | interesse_compra | finalizar_pedido | suporte | transferir_humano
+    /// Returns confidence 0-100; below 70 signals fallback to human.
+    /// </summary>
+    Task<AiConversationResponse> ProcessMessageAsync(
+        Guid tenantId,
+        string userMessage,
+        IEnumerable<ConversationMessageContext> history,
+        AiSalesContext context,
+        CancellationToken ct = default);
+}

--- a/src/VendaZap.Infrastructure/AI/OpenAiConversationService.cs
+++ b/src/VendaZap.Infrastructure/AI/OpenAiConversationService.cs
@@ -1,53 +1,107 @@
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using OpenAI;
 using OpenAI.Chat;
 using VendaZap.Application.Common.Interfaces;
+using VendaZap.Domain.Interfaces;
 
 namespace VendaZap.Infrastructure.AI;
 
-public class OpenAiConversationService : IAiConversationService
+public class OpenAiConversationService : IAiConversationService, IConversationAIService
 {
     private readonly OpenAIClient _client;
     private readonly ILogger<OpenAiConversationService> _logger;
     private readonly string _model;
 
+    private static readonly HashSet<string> ValidIntents = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "consulta_produto",
+        "interesse_compra",
+        "finalizar_pedido",
+        "suporte",
+        "transferir_humano"
+    };
+
     public OpenAiConversationService(IConfiguration config, ILogger<OpenAiConversationService> logger)
     {
         _logger = logger;
         var apiKey = config["OpenAI:ApiKey"] ?? throw new InvalidOperationException("OpenAI:ApiKey not configured.");
-        _model = config["OpenAI:Model"] ?? "gpt-4o-mini";
+        _model = config["OpenAI:Model"] ?? "gpt-4o";
         _client = new OpenAIClient(apiKey);
     }
 
-    public async Task<string> GetSalesResponseAsync(Guid tenantId, string userMessage, SalesContext context, CancellationToken ct = default)
+    // ── IConversationAIService (Domain) ─────────────────────────────────────
+
+    public async Task<AiConversationResponse> ProcessMessageAsync(
+        Guid tenantId,
+        string userMessage,
+        IEnumerable<ConversationMessageContext> history,
+        AiSalesContext context,
+        CancellationToken ct = default)
     {
-        var systemPrompt = BuildSalesSystemPrompt(context);
+        var systemPrompt = BuildStructuredSalesPrompt(context);
         var chatClient = _client.GetChatClient(_model);
 
         try
         {
-            var messages = new List<ChatMessage>
+            var messages = new List<ChatMessage> { new SystemChatMessage(systemPrompt) };
+
+            // Load last 20 messages as conversation history
+            foreach (var msg in history.TakeLast(20))
             {
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userMessage)
+                if (msg.Role.Equals("user", StringComparison.OrdinalIgnoreCase))
+                    messages.Add(new UserChatMessage(msg.Content));
+                else
+                    messages.Add(new AssistantChatMessage(msg.Content));
+            }
+
+            messages.Add(new UserChatMessage(userMessage));
+
+            var options = new ChatCompletionOptions
+            {
+                ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
             };
 
-            var response = await chatClient.CompleteChatAsync(messages, cancellationToken: ct);
-            return response.Value.Content[0].Text ?? "Olá! Como posso te ajudar?";
+            var response = await chatClient.CompleteChatAsync(messages, options, cancellationToken: ct);
+            var raw = response.Value.Content[0].Text ?? "{}";
+
+            return ParseStructuredResponse(raw);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "OpenAI API error for tenant {TenantId}", tenantId);
-            return "Desculpe, estou com dificuldades no momento. Pode tentar novamente?";
+            _logger.LogError(ex, "OpenAI structured response error for tenant {TenantId}", tenantId);
+            return new AiConversationResponse(
+                Message: "Desculpe, estou com dificuldades no momento. Pode tentar novamente?",
+                Intent: "suporte",
+                ProductsMentioned: [],
+                NextAction: "retry",
+                Confidence: 0);
         }
+    }
+
+    // ── IAiConversationService (Application – backward compat) ───────────────
+
+    public async Task<string> GetSalesResponseAsync(
+        Guid tenantId, string userMessage, SalesContext context, CancellationToken ct = default)
+    {
+        var aiContext = new AiSalesContext(
+            context.TenantName,
+            context.ContactName,
+            context.CurrentStage,
+            context.AvailableProducts.Select(p => new AiProductInfo(p.Id, p.Name, p.Price, p.Description, p.InStock)),
+            context.CartSummary,
+            context.PaymentInfo,
+            context.CustomInstructions);
+
+        var result = await ProcessMessageAsync(tenantId, userMessage, [], aiContext, ct);
+        return result.Message;
     }
 
     public async Task<string> GetResponseAsync(
         Guid tenantId, string conversationThreadId, string userMessage,
         string systemContext, CancellationToken ct = default)
     {
-        // For stateless completion (simpler flow)
         var chatClient = _client.GetChatClient(_model);
 
         var messages = new List<ChatMessage>
@@ -61,48 +115,95 @@ public class OpenAiConversationService : IAiConversationService
     }
 
     public Task<string> CreateThreadAsync(CancellationToken ct = default)
-    {
-        // Using a simple UUID as thread ID for conversation tracking
-        // In a full implementation, use OpenAI Assistants API threads
-        return Task.FromResult(Guid.NewGuid().ToString("N"));
-    }
+        => Task.FromResult(Guid.NewGuid().ToString("N"));
 
     public Task<bool> DeleteThreadAsync(string threadId, CancellationToken ct = default)
         => Task.FromResult(true);
 
-    private static string BuildSalesSystemPrompt(SalesContext context)
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string BuildStructuredSalesPrompt(AiSalesContext context)
     {
         var productsText = context.AvailableProducts.Any()
             ? string.Join("\n", context.AvailableProducts.Select(p =>
-                $"- {p.Name}: R$ {p.Price:F2} | {(p.InStock ? "Disponível" : "Indisponível")} | {p.Description}"))
+                $"- {p.Name} (id:{p.Id}): R$ {p.Price:F2} | {(p.InStock ? "Disponível" : "Indisponível")} | {p.Description}"))
             : "Nenhum produto cadastrado.";
 
         return $"""
             Você é um assistente de vendas via WhatsApp da loja "{context.TenantName}".
             Seu objetivo é ajudar o cliente a comprar de forma simples, amigável e eficiente.
-            
+
             REGRAS IMPORTANTES:
             - Responda SEMPRE em português brasileiro
             - Seja amigável, use emojis com moderação
             - Responda de forma CURTA e OBJETIVA (máximo 3 linhas por mensagem)
-            - Nunca invente produtos que não estejam na lista
+            - Nunca invente produtos que não estejam na lista abaixo
             - Quando o cliente quiser comprar, colete: quantidade → endereço → confirme pedido
             - Se não souber responder, diga que vai verificar e ofereça chamar um atendente
             - NUNCA discuta política, religião ou assuntos fora do contexto de vendas
-            - Se o cliente pedir para falar com humano, diga "Vou chamar um atendente para você."
-            
+            - Se o cliente pedir para falar com humano, use intent "transferir_humano"
+
             CLIENTE: {context.ContactName}
             ETAPA ATUAL: {context.CurrentStage}
-            
+
             PRODUTOS DISPONÍVEIS:
             {productsText}
-            
-            {(context.CartSummary != "{}" ? $"CARRINHO ATUAL:\n{context.CartSummary}" : "")}
-            
+
+            {(context.CartSummary != null && context.CartSummary != "{}" ? $"CARRINHO ATUAL:\n{context.CartSummary}" : "")}
+
             PAGAMENTO:
             {context.PaymentInfo}
-            
+
             {(context.CustomInstructions != null ? $"INSTRUÇÕES ESPECIAIS DO LOJISTA:\n{context.CustomInstructions}" : "")}
+
+            FORMATO DE RESPOSTA (JSON obrigatório):
+            {{
+              "message": "<resposta em português para o cliente>",
+              "intent": "<um de: consulta_produto | interesse_compra | finalizar_pedido | suporte | transferir_humano>",
+              "products_mentioned": ["<nome do produto>"],
+              "next_action": "<continue | collect_address | confirm_order | transfer_human | close>",
+              "confidence": <número inteiro 0-100 indicando sua confiança na resposta>
+            }}
+
+            Se sua confiança for menor que 70, prefira intent "transferir_humano".
+            Responda APENAS com o JSON, sem markdown ou texto extra.
             """;
+    }
+
+    private static AiConversationResponse ParseStructuredResponse(string raw)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            var root = doc.RootElement;
+
+            var message = root.TryGetProperty("message", out var msgEl) ? msgEl.GetString() ?? "" : "";
+            var intentRaw = root.TryGetProperty("intent", out var intentEl) ? intentEl.GetString() ?? "suporte" : "suporte";
+            var intent = ValidIntents.Contains(intentRaw) ? intentRaw : "suporte";
+            var nextAction = root.TryGetProperty("next_action", out var naEl) ? naEl.GetString() ?? "continue" : "continue";
+            var confidence = root.TryGetProperty("confidence", out var confEl) ? confEl.GetInt32() : 50;
+
+            var products = new List<string>();
+            if (root.TryGetProperty("products_mentioned", out var prodEl) && prodEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in prodEl.EnumerateArray())
+                {
+                    var name = item.GetString();
+                    if (!string.IsNullOrWhiteSpace(name)) products.Add(name);
+                }
+            }
+
+            return new AiConversationResponse(message, intent, products, nextAction, confidence);
+        }
+        catch
+        {
+            // If the model didn't return valid JSON, wrap the raw text
+            return new AiConversationResponse(
+                Message: raw,
+                Intent: "suporte",
+                ProductsMentioned: [],
+                NextAction: "continue",
+                Confidence: 50);
+        }
     }
 }

--- a/src/VendaZap.Infrastructure/DependencyInjection.cs
+++ b/src/VendaZap.Infrastructure/DependencyInjection.cs
@@ -133,7 +133,10 @@ public static class DependencyInjection
 
     private static IServiceCollection AddAiService(this IServiceCollection services, IConfiguration config)
     {
-        services.AddScoped<IAiConversationService, OpenAiConversationService>();
+        // Register the concrete service once; both interfaces resolve to the same instance per scope.
+        services.AddScoped<OpenAiConversationService>();
+        services.AddScoped<IAiConversationService>(sp => sp.GetRequiredService<OpenAiConversationService>());
+        services.AddScoped<IConversationAIService>(sp => sp.GetRequiredService<OpenAiConversationService>());
         return services;
     }
 


### PR DESCRIPTION
- Cria IConversationAIService no Domain com tipos AiConversationResponse,
  ConversationMessageContext, AiSalesContext e AiProductInfo
- Atualiza OpenAiConversationService para implementar IConversationAIService:
  carrega histórico das últimas 20 mensagens como contexto, solicita
  resposta estruturada em JSON com intent, products_mentioned, next_action
  e confidence; detecta intenções consulta_produto, interesse_compra,
  finalizar_pedido, suporte e transferir_humano
- Atualiza ProcessInboundMessageCommandHandler: usa IConversationAIService,
  passa histórico ao AI, faz fallback para humano quando confiança < 70%,
  avança estágio da conversa de acordo com a intenção detectada

https://claude.ai/code/session_01QK8PqRLp6y1mdofpE9kAJb